### PR TITLE
Feat-queue-length

### DIFF
--- a/hsm.go
+++ b/hsm.go
@@ -245,11 +245,11 @@ type queue struct {
 	events []Event
 }
 
-// func (q *queue) len() int {
-// 	q.mutex.RLock()
-// 	defer q.mutex.RUnlock()
-// 	return len(q.events)
-// }
+func (q *queue) len() int {
+	q.mutex.RLock()
+	defer q.mutex.RUnlock()
+	return len(q.events)
+}
 
 func (q *queue) pop() (Event, bool) {
 	q.mutex.Lock()
@@ -1188,6 +1188,7 @@ type Context interface {
 	State() string
 	// Dispatch sends an event to the state machine and returns a channel that closes when processing completes.
 	Dispatch(ctx context.Context, event Event) <-chan struct{}
+	QueueLen() int
 	Stop(ctx context.Context) <-chan struct{}
 	start(Context)
 }
@@ -1791,6 +1792,10 @@ func (sm *hsm[T]) process(ctx context.Context) {
 		event, ok = sm.queue.pop()
 	}
 	sm.queue.push(deferred...)
+}
+
+func (sm *hsm[T]) QueueLen() int {
+	return sm.queue.len()
 }
 
 func (sm *hsm[T]) Dispatch(ctx context.Context, event Event) <-chan struct{} {

--- a/hsm_test.go
+++ b/hsm_test.go
@@ -2,6 +2,7 @@ package hsm_test
 
 import (
 	"context"
+	"log/slog"
 	"os"
 	"slices"
 	"testing"
@@ -580,7 +581,10 @@ func BenchmarkHSM(b *testing.B) {
 		benchSM.Dispatch(ctx, fooEvent)
 		benchSM.Dispatch(ctx, barEvent)
 	}
+	slog.Info("done", "queue", benchSM.QueueLen())
 	<-benchSM.Stop(ctx)
+	slog.Info("done", "queue", benchSM.QueueLen())
+
 }
 
 func nonHSMLogic() func(event *hsm.Event) bool {

--- a/kind/kind.go
+++ b/kind/kind.go
@@ -117,7 +117,7 @@ var (
 	Event           = Kind(id.Next(), Element)
 	CompletionEvent = Kind(id.Next(), Event)
 	TimeEvent       = Kind(id.Next(), Event)
-	ErrorEvent      = Kind(id.Next(), Event)
+	ErrorEvent      = Kind(id.Next(), CompletionEvent)
 	Pseudostate     = Kind(id.Next(), Vertex)
 	Initial         = Kind(id.Next(), Pseudostate)
 	FinalState      = Kind(id.Next(), State)


### PR DESCRIPTION
- Implement QueueLen method in HSM to retrieve current event queue length
- Modify ErrorEvent kind to inherit from CompletionEvent
- Add logging in benchmark to demonstrate queue length functionality