### PR TITLE
Feat-every

### DIFF
--- a/elements/elements.go
+++ b/elements/elements.go
@@ -14,9 +14,13 @@ type NamedElement interface {
 	Name() string
 }
 
-type Model interface {
+type Namespace interface {
 	NamedElement
-	Namespace() map[string]NamedElement
+	Members() map[string]NamedElement
+}
+
+type Model interface {
+	Namespace
 }
 
 type Transition interface {
@@ -24,7 +28,7 @@ type Transition interface {
 	Source() string
 	Target() string
 	Guard() string
-	Effect() string
+	Effect() []string
 	Events() []Event
 }
 
@@ -35,9 +39,9 @@ type Vertex interface {
 
 type State interface {
 	Vertex
-	Entry() string
+	Entry() []string
 	Activities() []string
-	Exit() string
+	Exit() []string
 }
 
 type Event struct {

--- a/kind/kind.go
+++ b/kind/kind.go
@@ -82,6 +82,8 @@ type kinds struct {
 	Behavior        uint64
 	Concurrent      uint64
 	StateMachine    uint64
+	Namespace       uint64
+	Attribute       uint64
 	State           uint64
 	Transition      uint64
 	Internal        uint64
@@ -103,6 +105,7 @@ var (
 	Null            = Kind(id.Next())
 	Element         = Kind(id.Next())
 	Namespace       = Kind(id.Next(), Element)
+	Attribute       = Kind(id.Next(), Element)
 	Vertex          = Kind(id.Next(), Element)
 	Constraint      = Kind(id.Next(), Element)
 	Behavior        = Kind(id.Next(), Element)
@@ -135,6 +138,8 @@ var Kinds = sync.OnceValue(func() (kinds kinds) {
 	kinds.StateMachine = StateMachine
 	kinds.State = State
 	kinds.Transition = Transition
+	kinds.Namespace = Namespace
+	kinds.Attribute = Attribute
 	kinds.Internal = Internal
 	kinds.External = External
 	kinds.Local = Local


### PR DESCRIPTION
- Rename Model's Namespace method to Members for clarity
- Update state and transition structures to support multiple entry, exit, and effect actions
- Modify event processing to handle new structure and improve context management
- Add TestEvery to validate timing and order of events in state transitions
- Adjust tests to reflect changes in context handling and state machine behavior