### PR TITLE
Fix-stop

### DIFF
--- a/elements/elements.go
+++ b/elements/elements.go
@@ -1,5 +1,7 @@
 package elements
 
+import "github.com/runpod/hsm/muid"
+
 type Type interface{}
 
 type Element interface {
@@ -45,10 +47,10 @@ type State interface {
 }
 
 type Event struct {
-	Kind uint64 `json:"kind"`
-	Name string `json:"name"`
-	Id   string `json:"id"`
-	Data any    `json:"data"`
+	Kind uint64    `json:"kind"`
+	Name string    `json:"name"`
+	Id   muid.MUID `json:"id"`
+	Data any       `json:"data"`
 
 	// Deprecated: HSM now waits for all events by default
 	Done chan struct{} `json:"-"`

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,9 @@
 module github.com/runpod/hsm
 
 go 1.22.5
+
+require (
+	github.com/godruoyi/go-snowflake v0.0.2
+	github.com/google/uuid v1.6.0
+	github.com/oklog/ulid/v2 v2.1.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+github.com/godruoyi/go-snowflake v0.0.2 h1:rN9imTkrUJ5ZjuwTOi7kTGQFEZSUI3pwPMzAb7uitk4=
+github.com/godruoyi/go-snowflake v0.0.2/go.mod h1:6JXMZzmleLpSK9pYpg4LXTcAz54mdYXTeXUvVks17+4=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/oklog/ulid/v2 v2.1.0 h1:+9lhoxAP56we25tyYETBBY1YLA2SaoLvUFgrP2miPJU=
+github.com/oklog/ulid/v2 v2.1.0/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
+github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=

--- a/hsm.go
+++ b/hsm.go
@@ -1228,20 +1228,6 @@ func Final(name string) RedefinableElement {
 	}
 }
 
-// Log logs a message at a given level for a given instance.
-//
-// Example:
-//
-//	hsm.State("process",
-//	    hsm.Entry(hsm.Log(slog.LevelInfo, "Entering state process")),
-//	    )
-func Log[T Instance](level slog.Level, msg string, args ...any) func(ctx context.Context, instance T, event Event) {
-	return func(ctx context.Context, instance T, event Event) {
-		args := append([]any{"id", instance.Id(), "name", instance.Name(), "state", instance.State(), "event", event}, args...)
-		instance.Log(instance.Context(), level, msg, args...)
-	}
-}
-
 // func Attribute(name string, maybeDefaultValue ...any) RedefinableElement {
 // 	traceback := traceback()
 // 	return func(model *Model, stack []elements.NamedElement) elements.NamedElement {
@@ -1260,25 +1246,23 @@ func Log[T Instance](level slog.Level, msg string, args ...any) func(ctx context
 // 	}
 // }
 
-type Logger interface {
-	Log(ctx context.Context, level slog.Level, msg string, args ...any)
-}
-
 // Instance represents an active state machine instance that can process events and track state.
 // It provides methods for event dispatch and state management.
 type Instance interface {
-	Element
-	Logger
 	// State returns the current state's qualified name.
 	State() string
 	Context() context.Context
 	// Dispatch sends an event to the state machine and returns a channel that closes when processing completes.
 	Dispatch(ctx context.Context, event Event) <-chan struct{}
-	// Wait(ctx context.Context) <-chan struct{}
-	// QueueLen() int
-	start(Instance, *Event)
+
+	// non exported
+	id() string
+	qualifiedName() string
+	name() string
+	wait(ctx context.Context) <-chan struct{}
+	start(ctx context.Context, instance Instance, event *Event)
 	stop(ctx context.Context) <-chan struct{}
-	restart(ctx context.Context)
+	restart(ctx context.Context, maybeData ...any) <-chan struct{}
 }
 
 // Deprecated: Use Instance instead. Context will be removed in a future version.
@@ -1293,16 +1277,19 @@ type Context = Instance
 //	    hsm.HSM
 //	    counter int
 //	}
+
+type instance = Instance
+
 type HSM struct {
-	Instance
+	instance
 }
 
-func (hsm *HSM) start(instance Instance, event *Event) {
-	if hsm == nil || hsm.Instance != nil {
+func (hsm *HSM) start(ctx context.Context, instance Instance, event *Event) {
+	if hsm == nil || hsm.instance != nil {
 		return
 	}
-	hsm.Instance = instance
-	instance.start(hsm, event)
+	hsm.instance = instance
+	instance.start(ctx, hsm, event)
 }
 
 type subcontext = context.Context
@@ -1347,36 +1334,25 @@ func (mutex *mutex) tryLock() bool {
 }
 
 type hsm[T Instance] struct {
-	behavior[T]
+	behavior   behavior[T]
 	context    context.Context
 	state      atomic.Value
 	model      *Model
 	active     map[string]*active
 	queue      queue
 	instance   T
-	trace      Trace
 	timeouts   timeouts
 	processing mutex
-	logger     Logger
 }
-
-// Trace is a function type for tracing state machine execution.
-// It receives the current context, a step description, and optional data.
-// It returns a modified context and a completion function.
-type Trace func(ctx context.Context, sm Instance, step string, data ...any) (context.Context, func(...any))
 
 // Config provides configuration options for state machine initialization.
 type Config struct {
-	// Trace is a function that receives state machine execution events for debugging or monitoring.
-	Trace Trace
 	// Id is a unique identifier for the state machine instance.
 	Id string
-	// TerminateTimeout is the timeout for the state activity to terminate.
-	TerminateTimeout time.Duration
+	// ActivityTimeout is the timeout for the state activity to terminate.
+	ActivityTimeout time.Duration
 	// Name is the name of the state machine.
 	Name string
-	// Logger is a logger for the state machine.
-	Logger Logger
 	// Data to be passed during initialization
 	Data any
 }
@@ -1511,27 +1487,25 @@ func Start[T Instance](ctx context.Context, sm T, model *Model, config ...Config
 	initialEvent := InitialEvent
 	hsm.processing.lock()
 	if len(config) > 0 {
-		hsm.trace = config[0].Trace
-		hsm.id = config[0].Id
-		hsm.timeouts.terminate = config[0].TerminateTimeout
-		hsm.qualifiedName = config[0].Name
-		hsm.logger = config[0].Logger
+		hsm.behavior.id = config[0].Id
+		hsm.timeouts.terminate = config[0].ActivityTimeout
+		hsm.behavior.qualifiedName = config[0].Name
 		initialEvent = initialEvent.WithData(config[0].Data)
 	}
-	if hsm.id == "" {
-		hsm.id = muid.Make().String()
+	if hsm.behavior.id == "" {
+		hsm.behavior.id = muid.Make().String()
 	}
-	if hsm.qualifiedName == "" {
-		hsm.qualifiedName = model.QualifiedName()
+	if hsm.behavior.qualifiedName == "" {
+		hsm.behavior.qualifiedName = model.QualifiedName()
 	}
 	if hsm.timeouts.terminate == 0 {
 		hsm.timeouts.terminate = time.Millisecond
 	}
-	hsm.operation = func(ctx context.Context, _ T, event Event) {
+	hsm.behavior.operation = func(ctx context.Context, _ T, event Event) {
 		hsm.state.Store(hsm.enter(ctx, &hsm.model.state, &event, true))
 		hsm.process(ctx)
 	}
-	sm.start(hsm, &initialEvent)
+	sm.start(ctx, hsm, &initialEvent)
 	return sm
 }
 
@@ -1546,13 +1520,13 @@ func (sm *hsm[T]) State() string {
 	return state.QualifiedName()
 }
 
-func (sm *hsm[T]) start(instance Instance, event *Event) {
+func (sm *hsm[T]) start(_ context.Context, instance Instance, event *Event) {
 	all, ok := sm.context.Value(Keys.Instances).(*atomic.Pointer[[]Instance])
 	if !ok {
 		all = &atomic.Pointer[[]Instance]{}
 		all.Store(&[]Instance{})
 	}
-	ctx := sm.activate(context.WithValue(context.WithValue(sm.context, Keys.Instances, all), Keys.HSM, sm), sm)
+	ctx := sm.activate(context.WithValue(context.WithValue(sm.context, Keys.Instances, all), Keys.HSM, sm), &sm.behavior)
 	sm.context = ctx
 	for {
 		allInstances := all.Load()
@@ -1564,27 +1538,28 @@ func (sm *hsm[T]) start(instance Instance, event *Event) {
 	sm.execute(sm.context, &sm.behavior, event)
 }
 
-func (sm *hsm[T]) restart(ctx context.Context) {
+func (sm *hsm[T]) restart(ctx context.Context, maybeData ...any) <-chan struct{} {
+	var data any
+	if len(maybeData) > 0 {
+		data = maybeData[0]
+	}
 	<-sm.stop(ctx)
 	sm.processing.lock()
-	(*hsm[T])(sm).start(sm, &InitialEvent)
+	initialEvent := InitialEvent.WithData(data)
+	(*hsm[T])(sm).start(ctx, sm, &initialEvent)
+	return sm.wait(ctx)
 }
 
 func (sm *hsm[T]) stop(ctx context.Context) <-chan struct{} {
 	if sm == nil {
 		return closedChannel
 	}
-	if sm.trace != nil {
-		var end func(...any)
-		ctx, end = sm.trace(ctx, sm, "stop", sm.state)
-		defer end()
-	}
-	done := make(chan struct{})
+	signal := make(chan struct{})
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
-				sm.Log(ctx, slog.LevelError, "panic in stop: %s", r)
-				close(done)
+				slog.Default().Error("panic in stop", "error", r)
+				close(signal)
 			}
 		}()
 		sm.processing.lock()
@@ -1605,7 +1580,7 @@ func (sm *hsm[T]) stop(ctx context.Context) <-chan struct{} {
 			}
 			break
 		}
-		if active, ok := sm.active[sm.QualifiedName()]; ok {
+		if active, ok := sm.active[sm.behavior.qualifiedName]; ok {
 			active.cancel()
 		}
 		clear(sm.active)
@@ -1624,17 +1599,10 @@ func (sm *hsm[T]) stop(ctx context.Context) <-chan struct{} {
 				}
 			}
 		}
-		close(done)
+		close(signal)
 		sm.processing.unlock()
 	}()
-	return done
-}
-
-func (sm *hsm[T]) Log(ctx context.Context, level slog.Level, msg string, args ...any) {
-	if sm == nil || sm.logger == nil {
-		return
-	}
-	sm.logger.Log(ctx, level, msg, args...)
+	return signal
 }
 
 func (sm *hsm[T]) Context() context.Context {
@@ -1644,23 +1612,11 @@ func (sm *hsm[T]) Context() context.Context {
 	return sm.context
 }
 
-func (sm *hsm[T]) Wait(ctx context.Context) <-chan struct{} {
+func (sm *hsm[T]) wait(ctx context.Context) <-chan struct{} {
 	if sm == nil {
 		return closedChannel
 	}
 	return sm.processing.wait()
-}
-
-// Stop gracefully stops a state machine instance.
-// It cancels any running activities and prevents further event processing.
-//
-// Example:
-//
-//	sm := hsm.Start(...)
-//	// ... use state machine ...
-//	hsm.Stop(sm)
-func Stop(ctx context.Context, hsm Instance) <-chan struct{} {
-	return hsm.stop(ctx)
 }
 
 func (sm *hsm[T]) activate(ctx context.Context, element elements.NamedElement) *active {
@@ -1682,11 +1638,6 @@ func (sm *hsm[T]) activate(ctx context.Context, element elements.NamedElement) *
 func (sm *hsm[T]) enter(ctx context.Context, element elements.NamedElement, event *Event, defaultEntry bool) elements.NamedElement {
 	if sm == nil {
 		return nil
-	}
-	if sm.trace != nil {
-		var end func(...any)
-		ctx, end = sm.trace(ctx, sm, "enter", element)
-		defer end()
 	}
 	switch element.Kind() {
 	case kind.State:
@@ -1726,7 +1677,7 @@ func (sm *hsm[T]) enter(ctx context.Context, element elements.NamedElement, even
 		}
 	case kind.FinalState:
 		if element.Owner() == "/" {
-			sm.terminate(ctx, sm)
+			sm.terminate(ctx, &sm.behavior)
 		}
 		return element
 	}
@@ -1736,11 +1687,6 @@ func (sm *hsm[T]) enter(ctx context.Context, element elements.NamedElement, even
 func (sm *hsm[T]) exit(ctx context.Context, element elements.NamedElement, event *Event) {
 	if sm == nil || element == nil {
 		return
-	}
-	if sm.trace != nil {
-		var end func(...any)
-		ctx, end = sm.trace(ctx, sm, "exit", element)
-		defer end()
 	}
 	if state, ok := element.(*state); ok {
 		for _, activity := range state.activities {
@@ -1761,20 +1707,11 @@ func (sm *hsm[T]) execute(ctx context.Context, element *behavior[T], event *Even
 	if sm == nil || element == nil {
 		return
 	}
-	var end func(...any)
-	if sm.trace != nil {
-		var end func(...any)
-		ctx, end = sm.trace(ctx, sm, "execute", element, event)
-		defer end()
-	}
 
 	switch element.Kind() {
 	case kind.Concurrent:
 		ctx := sm.activate(sm.context, element)
-		go func(ctx *active, end func(...any), event Event) {
-			if end != nil {
-				defer end()
-			}
+		go func(ctx *active, event Event) {
 			defer func() {
 				if r := recover(); r != nil {
 					go sm.Dispatch(ctx, ErrorEvent.WithData(fmt.Errorf("panic in concurrent behavior %s: %s", element.QualifiedName(), r)))
@@ -1782,7 +1719,7 @@ func (sm *hsm[T]) execute(ctx context.Context, element *behavior[T], event *Even
 			}()
 			element.operation(ctx, sm.instance, event)
 			ctx.channel <- struct{}{}
-		}(ctx, end, *event)
+		}(ctx, *event)
 	default:
 		element.operation(ctx, sm.instance, *event)
 	}
@@ -1792,11 +1729,6 @@ func (sm *hsm[T]) execute(ctx context.Context, element *behavior[T], event *Even
 func (sm *hsm[T]) evaluate(ctx context.Context, guard *constraint[T], event *Event) bool {
 	if sm == nil || guard == nil || guard.expression == nil {
 		return true
-	}
-	if sm.trace != nil {
-		var end func(...any)
-		ctx, end = sm.trace(ctx, sm, "evaluate", guard, event)
-		defer end()
 	}
 	return guard.expression(
 		ctx,
@@ -1808,11 +1740,6 @@ func (sm *hsm[T]) evaluate(ctx context.Context, guard *constraint[T], event *Eve
 func (sm *hsm[T]) transition(ctx context.Context, current elements.NamedElement, transition *transition, event *Event) elements.NamedElement {
 	if sm == nil {
 		return nil
-	}
-	if sm.trace != nil {
-		var end func(...any)
-		ctx, end = sm.trace(ctx, sm, "transition", current, transition, event)
-		defer end()
 	}
 	path, ok := transition.paths[current.QualifiedName()]
 	if !ok {
@@ -1854,10 +1781,6 @@ func (sm *hsm[T]) transition(ctx context.Context, current elements.NamedElement,
 func (sm *hsm[T]) terminate(ctx context.Context, element elements.NamedElement) {
 	if sm == nil || element == nil {
 		return
-	}
-	if sm.trace != nil {
-		_, end := sm.trace(ctx, sm, "terminate", element)
-		defer end()
 	}
 	active, ok := sm.active[element.QualifiedName()]
 	if !ok {
@@ -1906,11 +1829,6 @@ func (sm *hsm[T]) process(ctx context.Context) {
 	if sm == nil {
 		return
 	}
-	if sm.trace != nil {
-		var end func(...any)
-		ctx, end = sm.trace(ctx, sm, "process")
-		defer end()
-	}
 	var deferred []Event
 	event, ok := sm.queue.pop()
 	for ok {
@@ -1958,18 +1876,24 @@ func (sm *hsm[T]) Dispatch(ctx context.Context, event Event) <-chan struct{} {
 	if event.Kind == 0 {
 		event.Kind = kind.Event
 	}
-
-	if sm.trace != nil {
-		var end func(...any)
-		ctx, end = sm.trace(ctx, sm, "dispatch", event)
-		defer end()
-	}
 	sm.queue.push(event)
 	if sm.processing.tryLock() {
 		go sm.process(ctx)
 		return sm.processing.wait()
 	}
 	return sm.processing.wait()
+}
+
+func (sm *hsm[T]) id() string {
+	return sm.behavior.id
+}
+
+func (sm *hsm[T]) qualifiedName() string {
+	return sm.behavior.qualifiedName
+}
+
+func (sm *hsm[T]) name() string {
+	return sm.behavior.Name()
 }
 
 // Dispatch sends an event to a specific state machine instance.
@@ -2019,7 +1943,7 @@ func DispatchTo(ctx context.Context, event Event, maybeIds ...string) <-chan str
 		defer close(signal)
 		signals := make(map[int]<-chan struct{}, len(*instances))
 		for i, sm := range *instances {
-			if len(maybeIds) == 0 || Match(sm.Id(), maybeIds...) {
+			if len(maybeIds) == 0 || Match(sm.id(), maybeIds...) {
 				signals[i] = sm.Dispatch(ctx, event)
 			}
 		}
@@ -2116,4 +2040,32 @@ func InstancesFromContext(ctx context.Context) ([]Instance, bool) {
 		return nil, false
 	}
 	return *instancesPointer.Load(), true
+}
+
+// Stop gracefully stops a state machine instance.
+// It cancels any running activities and prevents further event processing.
+//
+// Example:
+//
+//	sm := hsm.Start(...)
+//	// ... use state machine ...
+//	hsm.Stop(sm)
+func Stop(ctx context.Context, hsm Instance) <-chan struct{} {
+	return hsm.stop(ctx)
+}
+
+func Restart(ctx context.Context, hsm Instance, maybeData ...any) <-chan struct{} {
+	return hsm.restart(ctx, maybeData...)
+}
+
+func Id(hsm Instance) string {
+	return hsm.id()
+}
+
+func QualifiedName(hsm Instance) string {
+	return hsm.qualifiedName()
+}
+
+func Name(hsm Instance) string {
+	return hsm.name()
 }

--- a/hsm_test.go
+++ b/hsm_test.go
@@ -867,6 +867,18 @@ func nonHSMLogic() func(event *hsm.Event) bool {
 	return handleEvent
 }
 
+func TestStop(t *testing.T) {
+	sm := hsm.Start(context.Background(), &THSM{}, &benchModel)
+	<-hsm.Stop(context.Background(), sm)
+	instances, ok := hsm.InstancesFromContext(sm.Context())
+	if !ok {
+		t.Fatalf("expected instances to be non-nil")
+	}
+	if len(instances) != 0 {
+		t.Fatalf("expected instances to be empty")
+	}
+}
+
 func BenchmarkNonHSM(b *testing.B) {
 	handler := nonHSMLogic()
 	b.ResetTimer()

--- a/hsm_test.go
+++ b/hsm_test.go
@@ -2,11 +2,9 @@ package hsm_test
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"os"
 	"slices"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -221,9 +219,8 @@ func TestHSM(t *testing.T) {
 	sm := hsm.Start(ctx, &THSM{
 		foo: 0,
 	}, &model, hsm.Config{
-		Trace: tracer,
-		Name:  "TestHSM",
-		Id:    "test",
+		Name: "TestHSM",
+		Id:   "test",
 	})
 	plantuml.Generate(os.Stdout, &model)
 	if sm.State() != "/s/s2/s21/s211" {
@@ -915,138 +912,27 @@ func BenchmarkHSMWithLargeData(b *testing.B) {
 	<-hsm.Stop(ctx, instance)
 }
 
-type TestLogger struct {
-	messages []string
-}
-
-func NewTestLogger() *TestLogger {
-	return &TestLogger{
-		messages: []string{},
-	}
-}
-
-func (l *TestLogger) Log(ctx context.Context, level slog.Level, msg string, args ...any) {
-	// Format message with args
-	formattedMsg := msg
-	if len(args) > 0 {
-		// Simple formatting that's good enough for our test
-		for i := 0; i < len(args)-1; i += 2 {
-			if i+1 < len(args) {
-				formattedMsg += fmt.Sprintf(" %v=%v", args[i], args[i+1])
-			}
-		}
-	}
-	l.messages = append(l.messages, formattedMsg)
-}
-
-func (l *TestLogger) Contains(substring string) bool {
-	for _, msg := range l.messages {
-		if strings.Contains(msg, substring) {
-			return true
-		}
-	}
-	return false
-}
-
-func (l *TestLogger) Reset() {
-	l.messages = []string{}
-}
-
-func (l *TestLogger) Messages() []string {
-	return l.messages
-}
-
-func TestLog(t *testing.T) {
-	// Create a test logger to capture log output
-	logger := NewTestLogger()
-
-	// Create a simple HSM model with logging in entry, exit, and effect actions
+func TestRestart(t *testing.T) {
 	model := hsm.Define(
-		"TestLogHSM",
-		hsm.State("foo",
-			hsm.Entry(hsm.Log[*THSM](slog.LevelInfo, "Entry action for foo state")),
-			hsm.Exit(hsm.Log[*THSM](slog.LevelInfo, "Exit action for foo state")),
-		),
-		hsm.State("bar",
-			hsm.Entry(hsm.Log[*THSM](slog.LevelInfo, "Entry action for bar state")),
-		),
-		hsm.Transition(
-			hsm.On("foo"),
-			hsm.Source("foo"),
-			hsm.Target("bar"),
-			hsm.Effect(hsm.Log[*THSM](slog.LevelInfo, "Effect action for foo->bar transition")),
-		),
+		"TestRestartHSM",
 		hsm.Initial(hsm.Target("foo")),
+		hsm.State("foo", hsm.Entry(noBehavior), hsm.Exit(noBehavior)),
+		hsm.Transition(hsm.On("foo"), hsm.Source("foo"), hsm.Target("bar")),
+		hsm.State("bar", hsm.Entry(noBehavior), hsm.Exit(noBehavior)),
 	)
-
-	// Create a context with the logger
-	ctx := context.Background()
-
-	// Start the state machine
-	sm := hsm.Start(
-		ctx,
-		&THSM{},
-		&model,
-		hsm.Config{
-			Id:     "test-hsm",
-			Name:   "test-hsm",
-			Logger: logger,
-		},
-	)
-
-	// Wait a bit longer for initial state entry
-	time.Sleep(100 * time.Millisecond)
-
-	// Check that we have the entry log for foo state
-	if !logger.Contains("Entry action for foo state ") {
-		t.Fatalf("Expected log output to contain entry action for foo state, got: %v", logger.Messages())
+	sm := hsm.Start(context.Background(), &THSM{}, &model)
+	if sm.State() != "/foo" {
+		t.Fatalf("Expected state to be foo, got: %s", sm.State())
 	}
-
-	// Reset the logger to start fresh
-	logger.Reset()
-
-	done := sm.Dispatch(ctx, hsm.Event{Name: "foo"})
-	<-done // Wait for the event to be processed
-
-	// Add a delay for logs to be processed
-	time.Sleep(100 * time.Millisecond)
-
-	// Check log output for exit, effect, and entry actions
-	if !logger.Contains("Exit action for foo state") {
-		t.Fatalf("Expected log output to contain exit action for foo state, got: %v", logger.Messages())
+	<-sm.Dispatch(context.Background(), hsm.Event{Name: "foo", Done: make(chan struct{})})
+	if sm.State() != "/bar" {
+		t.Fatalf("Expected state to be bar, got: %s", sm.State())
 	}
-	if !logger.Contains("Effect action for foo->bar transition") {
-		t.Fatalf("Expected log output to contain effect action for transition, got: %v", logger.Messages())
+	hsm.Restart(context.Background(), sm)
+	if sm.State() != "/foo" {
+		t.Fatalf("Expected state to be foo, got: %s", sm.State())
 	}
-	if !logger.Contains("Entry action for bar state") {
-		t.Fatalf("Expected log output to contain entry action for bar state, got: %v", logger.Messages())
-	}
-
-	// Clean up
-	<-hsm.Stop(ctx, sm)
 }
-
-// func TestRestart(t *testing.T) {
-// 	model := hsm.Define(
-// 		"TestRestartHSM",
-// 		hsm.Initial(hsm.Target("foo")),
-// 		hsm.State("foo", hsm.Entry(noBehavior), hsm.Exit(noBehavior)),
-// 		hsm.Transition(hsm.On("foo"), hsm.Source("foo"), hsm.Target("bar")),
-// 		hsm.State("bar", hsm.Entry(noBehavior), hsm.Exit(noBehavior)),
-// 	)
-// 	sm := hsm.Start(context.Background(), &THSM{}, &model)
-// 	if sm.State() != "/foo" {
-// 		t.Fatalf("Expected state to be foo, got: %s", sm.State())
-// 	}
-// 	<-sm.Dispatch(context.Background(), hsm.Event{Name: "foo", Done: make(chan struct{})})
-// 	if sm.State() != "/bar" {
-// 		t.Fatalf("Expected state to be bar, got: %s", sm.State())
-// 	}
-// 	sm.Restart(context.Background())
-// 	if sm.State() != "/foo" {
-// 		t.Fatalf("Expected state to be foo, got: %s", sm.State())
-// 	}
-// }
 
 func TestDispatch(t *testing.T) {
 	model := hsm.Define(

--- a/muid/muid.go
+++ b/muid/muid.go
@@ -97,6 +97,7 @@ var (
 
 	// Keep defaultConfig for NewGenerator defaults
 	defaultConfig = DefaultConfig()
+	shards        = defaultShards()
 )
 
 type Config struct {
@@ -233,7 +234,6 @@ func (g *Generator) ID() MUID {
 // Make generates a new MUID using the default sharded generators.
 // It distributes load across generators for better parallel performance.
 func Make() MUID {
-	shards := defaultShards()
 	// Atomically get the next index in a round-robin fashion.
 	idx := shards.idx.Add(1) % shards.size
 	return shards.pool[idx].ID()

--- a/muid/muid_test.go
+++ b/muid/muid_test.go
@@ -1,8 +1,12 @@
 package muid_test
 
 import (
+	"strconv"
 	"testing"
 
+	"github.com/godruoyi/go-snowflake"
+	"github.com/google/uuid"
+	"github.com/oklog/ulid/v2"
 	"github.com/runpod/hsm/muid"
 )
 
@@ -36,45 +40,109 @@ func TestMUIDStringLength(t *testing.T) {
 	}
 }
 
-// func BenchmarkMuid(b *testing.B) {
-// 	b.Run("muid", func(b *testing.B) {
-// 		for i := 0; i < b.N; i++ {
-// 			muid.Make()
-// 		}
-// 	})
-// 	b.Run("uuid", func(b *testing.B) {
-// 		for i := 0; i < b.N; i++ {
-// 			uuid.NewV7()
-// 		}
-// 	})
-
-// 	b.Run("muid_parallel", func(b *testing.B) {
-// 		b.RunParallel(func(pb *testing.PB) {
-// 			for pb.Next() {
-// 				muid.Make()
-// 			}
-// 		})
-// 	})
-
-// 	b.Run("uuid_parallel", func(b *testing.B) {
-// 		b.RunParallel(func(pb *testing.PB) {
-// 			for pb.Next() {
-// 				uuid.NewV7()
-// 			}
-// 		})
-// 	})
-// 	b.Run("muid_string", func(b *testing.B) {
-// 		for i := 0; i < b.N; i++ {
-// 			_ = muid.Make().String()
-// 		}
-// 	})
-// 	b.Run("uuid_string", func(b *testing.B) {
-// 		for i := 0; i < b.N; i++ {
-// 			uuid, err := uuid.NewV7()
-// 			if err != nil {
-// 				b.Fatal(err)
-// 			}
-// 			_ = uuid.String()
-// 		}
-// 	})
-// }
+func BenchmarkIds(b *testing.B) {
+	b.Run("uuid", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			uuid.NewV7()
+		}
+	})
+	b.Run("uuid_parallel", func(b *testing.B) {
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				uuid.NewV7()
+			}
+		})
+	})
+	b.Run("uuid_string", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			uuid, _ := uuid.NewV7()
+			_ = uuid.String()
+		}
+	})
+	b.Run("uuid_string_parallel", func(b *testing.B) {
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				uuid, _ := uuid.NewV7()
+				_ = uuid.String()
+			}
+		})
+	})
+	b.Run("snowflake", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			snowflake.ID()
+		}
+	})
+	b.Run("snowflake_parallel", func(b *testing.B) {
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				snowflake.ID()
+			}
+		})
+	})
+	b.Run("snowflake_string", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			id := snowflake.ID()
+			_ = strconv.FormatUint(id, 10)
+		}
+	})
+	b.Run("snowflake_string_parallel", func(b *testing.B) {
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				id := snowflake.ID()
+				_ = strconv.FormatUint(id, 10)
+			}
+		})
+	})
+	b.Run("ulid", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			ulid.Make()
+		}
+	})
+	b.Run("ulid_parallel", func(b *testing.B) {
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				ulid.Make()
+			}
+		})
+	})
+	b.Run("ulid_string", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			id := ulid.Make()
+			_ = id.String()
+		}
+	})
+	b.Run("ulid_string_parallel", func(b *testing.B) {
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				id := ulid.Make()
+				_ = id.String()
+			}
+		})
+	})
+	b.Run("muid", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			muid.Make()
+		}
+	})
+	b.Run("muid_parallel", func(b *testing.B) {
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				muid.Make()
+			}
+		})
+	})
+	b.Run("muid_string", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			id := muid.Make()
+			_ = id.String()
+		}
+	})
+	b.Run("muid_string_parallel", func(b *testing.B) {
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				id := muid.Make()
+				_ = id.String()
+			}
+		})
+	})
+}

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package hsm
 
 // Version is the current version of the hsm package.
-const Version = "v1.9.0"
+const Version = "v1.9.1"

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package hsm
 
 // Version is the current version of the hsm package.
-const Version = "v1.9.1"
+const Version = "v2.0.0"


### PR DESCRIPTION
- Introduced a new test, TestStop, to verify the behavior of the HSM stop method, ensuring that instances are correctly cleared from the context.
- Refactored the HSM stop method to utilize atomic pointers for managing instances, improving thread safety and performance.
- Updated the event ID handling in the HSM processing logic to use MUID instead of string, enhancing consistency in ID generation.
- Added a new utility function, InstancesFromContext, to retrieve instances from the context more efficiently.