### PR TITLE
Feat-never-duration

### DIFF
--- a/hsm.go
+++ b/hsm.go
@@ -1106,6 +1106,9 @@ func After[T Instance](expr func(ctx context.Context, hsm T, event Event) time.D
 				element: element{kind: kind.Concurrent, qualifiedName: path.Join(source.QualifiedName(), "activity", qualifiedName)},
 				operation: func(ctx context.Context, hsm T, _ Event) {
 					duration := expr(ctx, hsm, event)
+					if duration < 0 {
+						return
+					}
 					timer := time.NewTimer(duration)
 					select {
 					case <-timer.C:
@@ -1162,6 +1165,9 @@ func Every[T Instance](expr func(ctx context.Context, hsm T, event Event) time.D
 				element: element{kind: kind.Concurrent, qualifiedName: path.Join(source.QualifiedName(), "activity", qualifiedName)},
 				operation: func(ctx context.Context, hsm T, evt Event) {
 					duration := expr(ctx, hsm, evt)
+					if duration < 0 {
+						return
+					}
 					timer := time.NewTimer(duration)
 					defer timer.Stop()
 					for {

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package hsm
 
 // Version is the current version of the hsm package.
-const Version = "v1.9.1"
+const Version = "v1.9.1.0"

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package hsm
 
 // Version is the current version of the hsm package.
-const Version = "v1.9.1.0"
+const Version = "v1.9.1.1"


### PR DESCRIPTION
- Introduced a new test case, TestNeverAfter, to ensure that transitions with negative durations do not trigger effects.
- Updated the After and Every functions to return early when a negative duration is specified, preventing unintended behavior.
- Incremented version to v1.9.1.0 in version.go to reflect changes.