### PR TITLE
Feat listeners

### DIFF
--- a/hsm.go
+++ b/hsm.go
@@ -1113,7 +1113,7 @@ func After[T Instance](expr func(ctx context.Context, hsm T, event Event) time.D
 					select {
 					case <-timer.C:
 						timer.Stop()
-						hsm.Dispatch(ctx, event)
+						hsm.Dispatch(hsm.Context(), event)
 						return
 					case <-ctx.Done():
 						timer.Stop()
@@ -1173,7 +1173,7 @@ func Every[T Instance](expr func(ctx context.Context, hsm T, event Event) time.D
 					for {
 						select {
 						case <-timer.C:
-							<-hsm.Dispatch(ctx, event)
+							<-hsm.Dispatch(hsm.Context(), event)
 							timer.Reset(duration)
 						case <-ctx.Done():
 							return

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package hsm
 
 // Version is the current version of the hsm package.
-const Version = "v1.9.1.3"
+const Version = "v1.9.2"

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package hsm
 
 // Version is the current version of the hsm package.
-const Version = "v1.9.1.2"
+const Version = "v1.9.1.3"


### PR DESCRIPTION
This pull request introduces several enhancements and changes to the `hsm` package, focusing on improving event handling, adding support for waiting on specific state machine events, and updating tests to reflect these changes. Additionally, the version of the package has been incremented.

### Enhancements to Event Handling and State Management:
* Introduced a new `listeners` struct in the `hsm` package to manage `enter`, `exit`, and `event` listeners for state transitions. This allows for better tracking and handling of state machine events. (`[[1]](diffhunk://#diff-37ac319e5bb589d923695143ebc58d8a82533c83a3dfebecde1571e4b850dbceR1342-R1347)`, `[[2]](diffhunk://#diff-37ac319e5bb589d923695143ebc58d8a82533c83a3dfebecde1571e4b850dbceR1358)`)
* Added new methods `WaitForDispatch`, `WaitForEntry`, and `WaitForExit` to enable waiting for specific events, state entries, or exits in the state machine. (`[hsm.goR2043-R2066](diffhunk://#diff-37ac319e5bb589d923695143ebc58d8a82533c83a3dfebecde1571e4b850dbceR2043-R2066)`)
* Updated the `Instance` interface to replace the `wait` method with a `listeners` method, reflecting the new event listener mechanism. (`[hsm.goL1268-R1268](diffhunk://#diff-37ac319e5bb589d923695143ebc58d8a82533c83a3dfebecde1571e4b850dbceL1268-R1268)`)
* Modified the `transition` and `process` methods to close channels for listeners when state transitions or events are processed. (`[[1]](diffhunk://#diff-37ac319e5bb589d923695143ebc58d8a82533c83a3dfebecde1571e4b850dbceR1767-R1769)`, `[[2]](diffhunk://#diff-37ac319e5bb589d923695143ebc58d8a82533c83a3dfebecde1571e4b850dbceR1786-R1788)`, `[[3]](diffhunk://#diff-37ac319e5bb589d923695143ebc58d8a82533c83a3dfebecde1571e4b850dbceR1878-R1880)`)

### Code Refactoring:
* Updated the `After` and `Every` functions to use `hsm.Context()` instead of directly passing the context, ensuring consistency in context handling. (`[[1]](diffhunk://#diff-37ac319e5bb589d923695143ebc58d8a82533c83a3dfebecde1571e4b850dbceL1116-R1116)`, `[[2]](diffhunk://#diff-37ac319e5bb589d923695143ebc58d8a82533c83a3dfebecde1571e4b850dbceL1176-R1176)`)
* Replaced the `wait` method in the `restart` function with the new `processing.wait` method for consistency with the updated `listeners` implementation. (`[hsm.goL1556-R1563](diffhunk://#diff-37ac319e5bb589d923695143ebc58d8a82533c83a3dfebecde1571e4b850dbceL1556-R1563)`)

### Testing Improvements:
* Added a new test, `TestWait`, to validate the behavior of the `WaitForDispatch`, `WaitForEntry`, and `WaitForExit` methods, ensuring they correctly handle state transitions and event dispatches. (`[hsm_test.goR988-R1016](diffhunk://#diff-1d3a55d8861ac6467b59e1ead536fcdfdb7e501dd7e4e460c24bbca982913335R988-R1016)`)
* Updated the `Trace` struct in `hsm_test.go` to use a pointer to `sync.Mutex` for thread-safe operations. (`[[1]](diffhunk://#diff-1d3a55d8861ac6467b59e1ead536fcdfdb7e501dd7e4e460c24bbca982913335L20-R20)`, `[[2]](diffhunk://#diff-1d3a55d8861ac6467b59e1ead536fcdfdb7e501dd7e4e460c24bbca982913335L68-R66)`)
