### PR TITLE
Fix-after-names

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,9 +319,9 @@ entry := hsm.AfterEntry(sm.Context(), sm, "/active")
 // Listen for exit from the "/idle" state
 exit := hsm.AfterExit(sm.Context(), sm, "/idle")
 // Listen for the dispatch of an event named "myEvent"
-dispatched := hsm.AfterDispatched(sm.Context(), sm, hsm.Event{Name: "myEvent"})
+dispatched := hsm.AfterDispatch(sm.Context(), sm, hsm.Event{Name: "myEvent"})
 // Listen for the completion of processing for an event named "myEvent"
-processed := hsm.AfterProcessed(sm.Context(), sm, hsm.Event{Name: "myEvent"})
+processed := hsm.AfterProcess(sm.Context(), sm, hsm.Event{Name: "myEvent"})
 
 // Example usage: Wait for dispatch
 select {

--- a/hsm.go
+++ b/hsm.go
@@ -2040,12 +2040,12 @@ func PropagateAll(ctx context.Context, event Event) <-chan struct{} {
 	return signal
 }
 
-func AfterProcessed(ctx context.Context, hsm Instance, event Event) <-chan struct{} {
+func AfterProcess(ctx context.Context, hsm Instance, event Event) <-chan struct{} {
 	ch, _ := hsm.channels().processed.LoadOrStore(event.Name, make(chan struct{}))
 	return ch.(chan struct{})
 }
 
-func AfterDispatched(ctx context.Context, hsm Instance, event Event) <-chan struct{} {
+func AfterDispatch(ctx context.Context, hsm Instance, event Event) <-chan struct{} {
 	ch, _ := hsm.channels().dispatched.LoadOrStore(event.Name, make(chan struct{}))
 	return ch.(chan struct{})
 }

--- a/hsm_test.go
+++ b/hsm_test.go
@@ -992,8 +992,8 @@ func TestAfter(t *testing.T) {
 	}
 	entered := hsm.AfterEntry(sm.Context(), sm, "/bar")
 	exited := hsm.AfterExit(sm.Context(), sm, "/foo")
-	dispatched := hsm.AfterDispatched(sm.Context(), sm, hsm.Event{Name: "foo"})
-	processed := hsm.AfterProcessed(sm.Context(), sm, hsm.Event{Name: "foo"})
+	dispatched := hsm.AfterDispatch(sm.Context(), sm, hsm.Event{Name: "foo"})
+	processed := hsm.AfterProcess(sm.Context(), sm, hsm.Event{Name: "foo"})
 
 	<-hsm.Dispatch(sm.Context(), hsm.Event{Name: "foo"})
 	select {

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package hsm
 
 // Version is the current version of the hsm package.
-const Version = "v2.0.0"
+const Version = "v2.0.1"


### PR DESCRIPTION
- Renamed AfterProcessed to AfterProcess and AfterDispatched to AfterDispatch for consistency in naming conventions.
- Updated related test cases and documentation to reflect the new function names.
- Incremented version to v2.0.1 in version.go to signify the changes.