### PR TITLE
Feat-when

### DIFF
--- a/hsm_test.go
+++ b/hsm_test.go
@@ -217,7 +217,7 @@ func TestHSM(t *testing.T) {
 		foo: 0,
 	}, &model, hsm.Config{
 		Name: "TestHSM",
-		Id:   "test",
+		ID:   "test",
 	})
 	plantuml.Generate(os.Stdout, &model)
 	if sm.State() != "/s/s2/s21/s211" {
@@ -562,8 +562,8 @@ func TestDispatchTo(t *testing.T) {
 		hsm.Initial(hsm.Target("foo")),
 	)
 	ctx := context.Background()
-	sm1 := hsm.Start(ctx, &THSM{}, &model, hsm.Config{Id: "sm1"})
-	sm2 := hsm.Start(sm1.Context(), &THSM{}, &model, hsm.Config{Id: "sm2"})
+	sm1 := hsm.Start(ctx, &THSM{}, &model, hsm.Config{ID: "sm1"})
+	sm2 := hsm.Start(sm1.Context(), &THSM{}, &model, hsm.Config{ID: "sm2"})
 	if sm1.State() != "/foo" {
 		t.Fatal("state is not correct", "state", sm1.State())
 	}

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package hsm
 
 // Version is the current version of the hsm package.
-const Version = "v2.0.3"
+const Version = "v2.0.4"


### PR DESCRIPTION
- Introduced a 'When' transition that allows asynchronous event handling within state transitions, enabling more dynamic behavior in the state machine.
- Updated the state definition in tests to include activities, improving the model's capabilities.
- Refactored the execution flow to handle activities concurrently, enhancing performance and responsiveness.
- Added a new test case to validate the 'When' transition functionality, ensuring expected state changes occur as intended.