### PR TITLE
Feat/transition maps

### DIFF
--- a/hsm.go
+++ b/hsm.go
@@ -114,12 +114,10 @@ type Model struct {
 	state    state
 	members  map[string]elements.NamedElement
 	elements []RedefinableElement
-	// this is a lazy cache for events that don't match any transition in a state configuration. It means
-	// 1. the event is not deferred
-	// 2. the event is not matched by a transition in the state or any of the ancestor states
-	// 3. if the event matches but the guard fails, it is not a miss
-	// boosted invalid transition performance by 65%
-	missCache map[string]map[string]struct{} // stateQualifiedName -> Set<eventNames>
+	// transitionMap provides fast lookup of transitions by state and event name
+	transitionMap map[string]map[string][]*transition // stateQualifiedName -> eventName -> transitions
+	// deferredMap provides fast lookup of deferred events by state
+	deferredMap map[string]map[string]struct{} // stateQualifiedName -> Set<deferredEventNames>
 }
 
 func (model *Model) Members() map[string]elements.NamedElement {
@@ -329,8 +327,9 @@ func Define[T interface{ RedefinableElement | string }](nameOrRedefinableElement
 		state: state{
 			vertex: vertex{element: element{kind: kind.State, qualifiedName: "/", id: name}, transitions: []string{}},
 		},
-		elements:  redefinableElements,
-		missCache: map[string]map[string]struct{}{},
+		elements:      redefinableElements,
+		transitionMap: map[string]map[string][]*transition{},
+		deferredMap:   map[string]map[string]struct{}{},
 	}
 	model.members = map[string]elements.NamedElement{
 		"/": &model.state,
@@ -352,7 +351,85 @@ func Define[T interface{ RedefinableElement | string }](nameOrRedefinableElement
 		panic(fmt.Errorf("exit actions are not allowed on top level state machine %s", model.state.id))
 	}
 	model.qualifiedName = name
+	buildCaches(&model)
 	return model
+}
+
+func buildCaches(model *Model) {
+	// Build transitionMap and deferredMap for fast lookups
+	// For each state, we build a map that includes ALL transitions accessible from that state
+	// by walking up the hierarchy. This gives us O(1) lookup without hierarchy traversal at runtime.
+	
+	for qualifiedName, element := range model.members {
+		// Build transition maps for all vertex types (states, pseudostates, etc)
+		if _, ok := element.(elements.Vertex); !ok {
+			continue
+		}
+		
+		// Initialize maps for this state
+		model.transitionMap[qualifiedName] = make(map[string][]*transition)
+		model.deferredMap[qualifiedName] = make(map[string]struct{})
+		
+		// Build a path from root to current state
+		var pathToState []string
+		currentPath := qualifiedName
+		for currentPath != "" {
+			pathToState = append([]string{currentPath}, pathToState...)
+			if currentPath == "/" {
+				break
+			}
+			currentPath = path.Dir(currentPath)
+		}
+		
+		// Walk from state to root, so more specific transitions come first (higher priority)
+		for i := len(pathToState) - 1; i >= 0; i-- {
+			statePath := pathToState[i]
+			currentElement := model.members[statePath]
+			if currentElement == nil {
+				continue
+			}
+			
+			// Collect transitions at this level
+			if vertex, ok := currentElement.(elements.Vertex); ok {
+				for _, transitionQualifiedName := range vertex.Transitions() {
+					if trans := get[*transition](model, transitionQualifiedName); trans != nil {
+						// Add all transitions - more specific ones will be checked first in process
+						for _, eventName := range trans.events {
+							model.transitionMap[qualifiedName][eventName] = append(model.transitionMap[qualifiedName][eventName], trans)
+						}
+					}
+				}
+			}
+			
+			// Collect deferred events at this level
+			if state, ok := currentElement.(*state); ok {
+				for _, deferredEvent := range state.deferred {
+					// Check if this event has a transition at the current state level
+					// If so, it's not deferred from this state
+					hasTransition := false
+					if vertex, ok := element.(elements.Vertex); ok {
+						for _, transQualifiedName := range vertex.Transitions() {
+							if trans := get[*transition](model, transQualifiedName); trans != nil {
+								for _, eventName := range trans.events {
+									if eventName == deferredEvent {
+										hasTransition = true
+										break
+									}
+								}
+							}
+							if hasTransition {
+								break
+							}
+						}
+					}
+					
+					if !hasTransition {
+						model.deferredMap[qualifiedName][deferredEvent] = struct{}{}
+					}
+				}
+			}
+		}
+	}
 }
 
 func find(stack []elements.NamedElement, maybeKinds ...uint64) elements.NamedElement {
@@ -396,14 +473,6 @@ func getFunctionName(fn any) string {
 	return path.Base(runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name())
 }
 
-func hasWildcard(events ...string) bool {
-	for _, event := range events {
-		if strings.Contains(event, "*") {
-			return true
-		}
-	}
-	return false
-}
 
 // State creates a new state element with the given name and optional child elements.
 // States can have entry/exit actions, activities, and transitions.
@@ -447,15 +516,7 @@ func State(name string, partialElements ...RedefinableElement) RedefinableElemen
 					traceback(fmt.Errorf("missing transition \"%s\" for state \"%s\"", j, element.QualifiedName()))
 					return 1 // because the linter doesn't know that traceback will panic
 				}
-				// If j has wildcard and i doesn't, i comes first
-				hasWildcardI := hasWildcard(transitionI.events...)
-				hasWildcardJ := hasWildcard(transitionJ.events...)
-				if hasWildcardI && !hasWildcardJ {
-					return 1 // Sort transitionI (wildcard) after transitionJ
-				}
-				if !hasWildcardI && hasWildcardJ {
-					return -1 // Sort transitionI (non-wildcard) before transitionJ
-				}
+				// No wildcard prioritization needed anymore
 				return 0
 			})
 			return element
@@ -1859,13 +1920,33 @@ func (sm *hsm[T]) enabled(ctx context.Context, source elements.Vertex, event *Ev
 		return false, nil
 	}
 	matched := false
+	
+	// Use transitionMap for fast lookup if available
+	if eventTransitions, ok := sm.model.transitionMap[source.QualifiedName()]; ok {
+		if transitions, ok := eventTransitions[event.Name]; ok {
+			matched = true
+			for _, transition := range transitions {
+				if guard := get[*constraint[T]](sm.model, transition.Guard()); guard != nil {
+					if !sm.evaluate(ctx, guard, event) {
+						continue
+					}
+				}
+				return matched, transition
+			}
+		}
+		
+		// If we have a transitionMap for this state, we've checked all possibilities
+		return matched, nil
+	}
+	
+	// Fallback to original method if transitionMap not available
 	for _, transitionQualifiedName := range source.Transitions() {
 		transition := get[*transition](sm.model, transitionQualifiedName)
 		if transition == nil {
 			continue
 		}
 		for _, evt := range transition.Events() {
-			if !Match(event.Name, evt) {
+			if event.Name != evt {
 				continue
 			}
 			matched = true
@@ -1899,49 +1980,36 @@ func (sm *hsm[T]) process(ctx context.Context) {
 		}
 		currentState := sm.state.Load().(elements.NamedElement)
 		currentQualifiedName := currentState.QualifiedName()
-		misses, missesOk := sm.model.missCache[currentQualifiedName]
-		if missesOk {
-			if _, missed := misses[event.Name]; missed {
+		
+		// Check if event is deferred using O(1) lookup
+		if deferredSet, ok := sm.model.deferredMap[currentQualifiedName]; ok {
+			if _, isDeferred := deferredSet[event.Name]; isDeferred {
+				deferred = append(deferred, event)
 				event, ok = sm.queue.pop()
 				continue
 			}
 		}
-		qualifiedName := currentQualifiedName
-		miss := true
-		for qualifiedName != "" {
-			source := get[*state](sm.model, qualifiedName)
-			if source == nil {
-				break
-			}
-			matched, transition := sm.enabled(ctx, source, &event)
-			if matched {
-				miss = false
-			}
-			if transition != nil {
+		
+		// Direct O(1) lookup for transitions - no hierarchy walking needed
+		if transitions, ok := sm.model.transitionMap[currentQualifiedName][event.Name]; ok {
+			for _, transition := range transitions {
+				if guard := get[*constraint[T]](sm.model, transition.Guard()); guard != nil {
+					if !sm.evaluate(ctx, guard, &event) {
+						continue
+					}
+				}
 				state := sm.transition(ctx, currentState, transition, &event)
-				if state == nil {
-					break
-				}
-				sm.state.Store(state)
-				if len(deferred) > 0 {
-					sm.queue.push(deferred...)
-					deferred = nil
+				if state != nil {
+					sm.state.Store(state)
+					if len(deferred) > 0 {
+						sm.queue.push(deferred...)
+						deferred = nil
+					}
 				}
 				break
 			}
-			if len(source.deferred) > 0 && Match(event.Name, source.deferred...) {
-				deferred = append(deferred, event)
-				break
-			}
-			qualifiedName = source.Owner()
 		}
-		if miss {
-			if missesOk {
-				misses[event.Name] = struct{}{}
-			} else {
-				sm.model.missCache[currentQualifiedName] = map[string]struct{}{event.Name: {}}
-			}
-		}
+		
 		if ch, ok := sm.after.processed.LoadAndDelete(event.Name); ok {
 			close(ch.(chan struct{}))
 		}

--- a/hsm.go
+++ b/hsm.go
@@ -114,6 +114,12 @@ type Model struct {
 	state    state
 	members  map[string]elements.NamedElement
 	elements []RedefinableElement
+	// this is a lazy cache for events that don't match any transition in a state configuration. It means
+	// 1. the event is not deferred
+	// 2. the event is not matched by a transition in the state or any of the ancestor states
+	// 3. if the event matches but the guard fails, it is not a miss
+	// boosted invalid transition performance by 65%
+	missCache map[string]map[string]struct{} // stateQualifiedName -> Set<eventNames>
 }
 
 func (model *Model) Members() map[string]elements.NamedElement {
@@ -332,7 +338,8 @@ func Define[T interface{ RedefinableElement | string }](nameOrRedefinableElement
 		state: state{
 			vertex: vertex{element: element{kind: kind.State, qualifiedName: "/", id: name}, transitions: []string{}},
 		},
-		elements: redefinableElements,
+		elements:  redefinableElements,
+		missCache: map[string]map[string]struct{}{},
 	}
 	model.members = map[string]elements.NamedElement{
 		"/": &model.state,
@@ -1873,10 +1880,11 @@ func (sm *hsm[T]) terminate(ctx context.Context, element elements.NamedElement) 
 
 }
 
-func (sm *hsm[T]) enabled(ctx context.Context, source elements.Vertex, event *Event) *transition {
+func (sm *hsm[T]) enabled(ctx context.Context, source elements.Vertex, event *Event) (bool, *transition) {
 	if sm == nil {
-		return nil
+		return false, nil
 	}
+	matched := false
 	for _, transitionQualifiedName := range source.Transitions() {
 		transition := get[*transition](sm.model, transitionQualifiedName)
 		if transition == nil {
@@ -1886,15 +1894,16 @@ func (sm *hsm[T]) enabled(ctx context.Context, source elements.Vertex, event *Ev
 			if !Match(event.Name, evt) {
 				continue
 			}
+			matched = true
 			if guard := get[*constraint[T]](sm.model, transition.Guard()); guard != nil {
 				if !sm.evaluate(ctx, guard, event) {
 					continue
 				}
 			}
-			return transition
+			return matched, transition
 		}
 	}
-	return nil
+	return matched, nil
 }
 
 func (sm *hsm[T]) process(ctx context.Context) {
@@ -1915,13 +1924,26 @@ func (sm *hsm[T]) process(ctx context.Context) {
 			event.Id = muid.Make()
 		}
 		currentState := sm.state.Load().(elements.NamedElement)
-		qualifiedName := currentState.QualifiedName()
+		currentQualifiedName := currentState.QualifiedName()
+		misses, missesOk := sm.model.missCache[currentQualifiedName]
+		if missesOk {
+			if _, missed := misses[event.Name]; missed {
+				event, ok = sm.queue.pop()
+				continue
+			}
+		}
+		qualifiedName := currentQualifiedName
+		miss := true
 		for qualifiedName != "" {
 			source := get[*state](sm.model, qualifiedName)
 			if source == nil {
 				break
 			}
-			if transition := sm.enabled(ctx, source, &event); transition != nil {
+			matched, transition := sm.enabled(ctx, source, &event)
+			if matched {
+				miss = false
+			}
+			if transition != nil {
 				state := sm.transition(ctx, currentState, transition, &event)
 				if state == nil {
 					break
@@ -1938,6 +1960,13 @@ func (sm *hsm[T]) process(ctx context.Context) {
 				break
 			}
 			qualifiedName = source.Owner()
+		}
+		if miss {
+			if missesOk {
+				misses[event.Name] = struct{}{}
+			} else {
+				sm.model.missCache[currentQualifiedName] = map[string]struct{}{event.Name: {}}
+			}
 		}
 		if ch, ok := sm.after.processed.LoadAndDelete(event.Name); ok {
 			close(ch.(chan struct{}))

--- a/hsm.go
+++ b/hsm.go
@@ -154,7 +154,6 @@ type state struct {
 	exit       []string
 	activities []string
 	deferred   []string
-	regions    map[string]struct{}
 }
 
 func (state *state) Entry() []string {
@@ -167,14 +166,6 @@ func (state *state) Activities() []string {
 
 func (state *state) Exit() []string {
 	return state.exit
-}
-
-/******* Region *******/
-
-type region struct {
-	element
-	initial  string
-	vertices map[string]struct{}
 }
 
 /******* Transition *******/
@@ -525,23 +516,6 @@ func IsAncestor(current, target string) bool {
 		parent = path.Dir(parent)
 	}
 	return false
-}
-
-func Region(name string, partialElements ...RedefinableElement) RedefinableElement {
-	traceback := traceback()
-	return func(model *Model, stack []elements.NamedElement) elements.NamedElement {
-		owner := find(stack, kind.Namespace)
-		if owner == nil {
-			traceback(fmt.Errorf("region \"%s\" must be called within Define() or State()", name))
-		}
-		element := &region{
-			element: element{kind: kind.Region, qualifiedName: path.Join(owner.QualifiedName(), name)},
-		}
-		model.members[element.QualifiedName()] = element
-		stack = append(stack, element)
-		apply(model, stack, partialElements...)
-		return element
-	}
 }
 
 // Transition creates a new transition between states.

--- a/hsm_bench_test.go
+++ b/hsm_bench_test.go
@@ -83,7 +83,7 @@ func runHSMBenchmark(b *testing.B, modelHsm hsm.Model, event1Name, event2Name st
 	// Manually measure time instead of using b.N
 	start := time.Now()
 
-	for i := 0; i < benchmarkIterations; i++ {
+	for range benchmarkIterations {
 		<-m.Dispatch(ctx, event1)
 		<-m.Dispatch(ctx, event2)
 	}
@@ -95,7 +95,7 @@ func runHSMBenchmark(b *testing.B, modelHsm hsm.Model, event1Name, event2Name st
 	transitionsPerSec := totalTransitions / elapsed.Seconds()
 
 	// Set b.N to the actual number of operations for proper reporting
-	b.N = benchmarkIterations * 2
+	// b.N = benchmarkIterations * 2
 
 	// Report the time per operation (ns per transition)
 	nsPerTransition := elapsed.Nanoseconds() / int64(b.N)
@@ -273,4 +273,24 @@ func BenchmarkCrossHierarchyTransitions_EntryExit(b *testing.B) {
 		hsm.Initial(hsm.Target("/parent1")),
 	)
 	runHSMBenchmark(b, model, "toParent2", "toParent1")
+}
+
+// Invalid event handling (graceful failure performance test)
+func BenchmarkInvalidEventHandling(b *testing.B) {
+	model := hsm.Define(
+		"TestHSMInvalidEvents",
+		hsm.State("level1",
+			hsm.State("level2",
+				hsm.State("level3",
+					// Only has one valid transition
+					hsm.Transition(hsm.On("validEvent"), hsm.Target(".")),
+				),
+				hsm.Initial(hsm.Target("level3")),
+			),
+			hsm.Initial(hsm.Target("level2")),
+		),
+		hsm.Initial(hsm.Target("/level1")),
+	)
+	// Use fewer iterations for invalid events since they're processed faster
+	runHSMBenchmark(b, model, "invalidEvent1", "invalidEvent2")
 }

--- a/hsm_bench_test.go
+++ b/hsm_bench_test.go
@@ -1,0 +1,276 @@
+package hsm_test
+
+import (
+	"context"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/runpod/hsm/v2"
+)
+
+// BenchHSM is a wrapper for hsm.HSM for benchmarking purposes.
+type BenchHSM struct {
+	hsm.HSM
+	effectCounter int64
+}
+
+func (b *BenchHSM) ResetCounters() {
+	b.effectCounter = 0
+}
+
+// benchNoBehavior is a no-op action/activity function for benchmarks.
+func benchNoBehavior(_ context.Context, _ *BenchHSM, _ hsm.Event) {
+	// Do nothing
+}
+
+var activityWorkCounter atomic.Int64
+
+// activityBehavior simulates a minimal activity that runs until context is cancelled.
+func activityBehavior(ctx context.Context, b *BenchHSM, e hsm.Event) {
+	for {
+		select {
+		case <-ctx.Done(): // Context is cancelled when state is exited
+			return
+		default:
+			// Simulate minimal work by yielding the processor.
+			runtime.Gosched()
+			activityWorkCounter.Add(1) // Increment to show activity is doing work
+		}
+	}
+}
+
+// effectBehavior is an action function that performs a minimal operation.
+func effectBehavior(_ context.Context, b *BenchHSM, _ hsm.Event) {
+	b.effectCounter++
+}
+
+// benchNoGuard is a guard function that always returns true for benchmarks.
+func benchNoGuard(_ context.Context, _ *BenchHSM, _ hsm.Event) bool {
+	return true
+}
+
+// runHSMBenchmark is a helper to run a specific HSM benchmark scenario.
+func runHSMBenchmark(b *testing.B, modelHsm hsm.Model, event1Name, event2Name string) {
+	ctx := context.Background()
+	instance := &BenchHSM{}
+
+	// Pass model by reference to hsm.Start
+	m := hsm.Start(ctx, instance, &modelHsm)
+	if m == nil {
+		b.Fatalf("Failed to create HSM: hsm.Start returned nil")
+	}
+	// It's important to stop the HSM to clean up resources, especially activities.
+	defer hsm.Stop(ctx, m)
+
+	event1 := hsm.Event{Name: event1Name}
+	event2 := hsm.Event{Name: event2Name}
+
+	// Fixed warmup iterations to match C++ (1000)
+	warmupIterations := 1000
+	for i := 0; i < warmupIterations; i++ {
+		<-m.Dispatch(ctx, event1)
+		<-m.Dispatch(ctx, event2)
+	}
+
+	instance.ResetCounters()
+	activityWorkCounter.Store(0) // Reset global counters
+
+	// Fixed benchmark iterations to match C++ (1000)
+	benchmarkIterations := 1000
+
+	// Manually measure time instead of using b.N
+	start := time.Now()
+
+	for i := 0; i < benchmarkIterations; i++ {
+		<-m.Dispatch(ctx, event1)
+		<-m.Dispatch(ctx, event2)
+	}
+
+	elapsed := time.Since(start)
+
+	// Report using custom metrics
+	totalTransitions := float64(benchmarkIterations) * 2.0 // Two transitions per iteration
+	transitionsPerSec := totalTransitions / elapsed.Seconds()
+
+	// Set b.N to the actual number of operations for proper reporting
+	b.N = benchmarkIterations * 2
+
+	// Report the time per operation (ns per transition)
+	nsPerTransition := elapsed.Nanoseconds() / int64(b.N)
+	b.ReportMetric(float64(nsPerTransition), "ns/op")
+	b.ReportMetric(transitionsPerSec, "trans/sec")
+	b.ReportMetric(float64(benchmarkIterations), "iterations")
+}
+
+// --- Scenario 1: Nested states (matching C++ benchmark) ---
+
+// 1. Baseline: Nested states without entry, exit, or activities
+func BenchmarkNestedStates_NoEntryExitActivity(b *testing.B) {
+	model := hsm.Define(
+		"TestHSM1",
+		hsm.State("parent",
+			hsm.State("child1"),
+			hsm.State("child2"),
+			hsm.Initial(hsm.Target("child1")),
+			hsm.Transition(hsm.On("toChild2"), hsm.Source("child1"), hsm.Target("child2")),
+			hsm.Transition(hsm.On("toChild1"), hsm.Source("child2"), hsm.Target("child1")),
+		),
+		hsm.Initial(hsm.Target("/parent")),
+	)
+	runHSMBenchmark(b, model, "toChild2", "toChild1")
+}
+
+// 1.a Nested states with entry functions only
+func BenchmarkNestedStates_EntryOnly(b *testing.B) {
+	model := hsm.Define(
+		"TestHSM1a",
+		hsm.State("parent",
+			hsm.Entry(benchNoBehavior),
+			hsm.State("child1", hsm.Entry(benchNoBehavior)),
+			hsm.State("child2", hsm.Entry(benchNoBehavior)),
+			hsm.Initial(hsm.Target("child1")),
+			hsm.Transition(hsm.On("toChild2"), hsm.Source("child1"), hsm.Target("child2")),
+			hsm.Transition(hsm.On("toChild1"), hsm.Source("child2"), hsm.Target("child1")),
+		),
+		hsm.Initial(hsm.Target("/parent")),
+	)
+	runHSMBenchmark(b, model, "toChild2", "toChild1")
+}
+
+// 1.b Nested states with entry and activity functions
+func BenchmarkNestedStates_EntryActivity(b *testing.B) {
+	model := hsm.Define(
+		"TestHSM1b",
+		hsm.State("parent",
+			hsm.Entry(benchNoBehavior),
+			hsm.Activity(activityBehavior),
+			hsm.State("child1",
+				hsm.Entry(benchNoBehavior),
+				hsm.Activity(activityBehavior),
+			),
+			hsm.State("child2",
+				hsm.Entry(benchNoBehavior),
+				hsm.Activity(activityBehavior),
+			),
+			hsm.Initial(hsm.Target("child1")),
+			hsm.Transition(hsm.On("toChild2"), hsm.Source("child1"), hsm.Target("child2")),
+			hsm.Transition(hsm.On("toChild1"), hsm.Source("child2"), hsm.Target("child1")),
+		),
+		hsm.Initial(hsm.Target("/parent")),
+	)
+	runHSMBenchmark(b, model, "toChild2", "toChild1")
+}
+
+// 1.c Nested states with entry, exit, and activity functions
+func BenchmarkNestedStates_EntryExitActivity(b *testing.B) {
+	model := hsm.Define(
+		"TestHSM1c",
+		hsm.State("parent",
+			hsm.Entry(benchNoBehavior),
+			hsm.Exit(benchNoBehavior),
+			hsm.Activity(activityBehavior),
+			hsm.State("child1",
+				hsm.Entry(benchNoBehavior),
+				hsm.Exit(benchNoBehavior),
+				hsm.Activity(activityBehavior),
+			),
+			hsm.State("child2",
+				hsm.Entry(benchNoBehavior),
+				hsm.Exit(benchNoBehavior),
+				hsm.Activity(activityBehavior),
+			),
+			hsm.Initial(hsm.Target("child1")),
+			hsm.Transition(hsm.On("toChild2"), hsm.Source("child1"), hsm.Target("child2")),
+			hsm.Transition(hsm.On("toChild1"), hsm.Source("child2"), hsm.Target("child1")),
+		),
+		hsm.Initial(hsm.Target("/parent")),
+	)
+	runHSMBenchmark(b, model, "toChild2", "toChild1")
+}
+
+// 1.d Nested states with entry, exit, activity functions and transition effects
+func BenchmarkNestedStates_EntryExitActivityEffect(b *testing.B) {
+	model := hsm.Define(
+		"TestHSM1d",
+		hsm.State("parent",
+			hsm.Entry(benchNoBehavior),
+			hsm.Exit(benchNoBehavior),
+			hsm.Activity(activityBehavior),
+			hsm.State("child1",
+				hsm.Entry(benchNoBehavior),
+				hsm.Exit(benchNoBehavior),
+				hsm.Activity(activityBehavior),
+			),
+			hsm.State("child2",
+				hsm.Entry(benchNoBehavior),
+				hsm.Exit(benchNoBehavior),
+				hsm.Activity(activityBehavior),
+			),
+			hsm.Initial(hsm.Target("child1")),
+			hsm.Transition(hsm.On("toChild2"), hsm.Source("child1"), hsm.Target("child2"), hsm.Effect(effectBehavior)),
+			hsm.Transition(hsm.On("toChild1"), hsm.Source("child2"), hsm.Target("child1"), hsm.Effect(effectBehavior)),
+		),
+		hsm.Initial(hsm.Target("/parent")),
+	)
+	runHSMBenchmark(b, model, "toChild2", "toChild1")
+}
+
+// Additional test: Deep nesting (3 levels)
+func BenchmarkDeepNesting3Levels_EntryExit(b *testing.B) {
+	model := hsm.Define(
+		"TestHSMDeep",
+		hsm.State("level1",
+			hsm.Entry(benchNoBehavior),
+			hsm.Exit(benchNoBehavior),
+			hsm.State("level2",
+				hsm.Entry(benchNoBehavior),
+				hsm.Exit(benchNoBehavior),
+				hsm.State("level3a",
+					hsm.Entry(benchNoBehavior),
+					hsm.Exit(benchNoBehavior),
+				),
+				hsm.State("level3b",
+					hsm.Entry(benchNoBehavior),
+					hsm.Exit(benchNoBehavior),
+				),
+				hsm.Initial(hsm.Target("level3a")),
+				hsm.Transition(hsm.On("toLevel3b"), hsm.Source("level3a"), hsm.Target("level3b")),
+				hsm.Transition(hsm.On("toLevel3a"), hsm.Source("level3b"), hsm.Target("level3a")),
+			),
+			hsm.Initial(hsm.Target("level2")),
+		),
+		hsm.Initial(hsm.Target("/level1")),
+	)
+	runHSMBenchmark(b, model, "toLevel3b", "toLevel3a")
+}
+
+// Test exiting and entering nested states from outside
+func BenchmarkCrossHierarchyTransitions_EntryExit(b *testing.B) {
+	model := hsm.Define(
+		"TestHSMCrossHierarchy",
+		hsm.State("parent1",
+			hsm.Entry(benchNoBehavior),
+			hsm.Exit(benchNoBehavior),
+			hsm.State("child1",
+				hsm.Entry(benchNoBehavior),
+				hsm.Exit(benchNoBehavior),
+			),
+			hsm.Initial(hsm.Target("child1")),
+		),
+		hsm.State("parent2",
+			hsm.Entry(benchNoBehavior),
+			hsm.Exit(benchNoBehavior),
+			hsm.State("child2",
+				hsm.Entry(benchNoBehavior),
+				hsm.Exit(benchNoBehavior),
+			),
+			hsm.Initial(hsm.Target("child2")),
+		),
+		hsm.Transition(hsm.On("toParent2"), hsm.Source("parent1"), hsm.Target("parent2")),
+		hsm.Transition(hsm.On("toParent1"), hsm.Source("parent2"), hsm.Target("parent1")),
+		hsm.Initial(hsm.Target("/parent1")),
+	)
+	runHSMBenchmark(b, model, "toParent2", "toParent1")
+}

--- a/hsm_test.go
+++ b/hsm_test.go
@@ -133,7 +133,8 @@ func TestComplex(t *testing.T) {
 				hsm.Activity(mockAction("s3.activity", true)),
 				hsm.Exit(mockAction("s3.exit", false)),
 			),
-			hsm.Transition(hsm.On(`*.P.*`), hsm.Effect(mockAction("s11.P.transition.effect", false))),
+			// Wildcard events are no longer supported
+			// hsm.Transition(hsm.On(`*.P.*`), hsm.Effect(mockAction("s11.P.transition.effect", false))),
 		),
 		hsm.State("t",
 			hsm.Entry(mockAction("t.entry", false)),
@@ -170,7 +171,8 @@ func TestComplex(t *testing.T) {
 				return check
 			},
 		)),
-		hsm.Transition("wildcard", hsm.On("abcd*"), hsm.Source("/s"), hsm.Target("/s")),
+		// Wildcard events are no longer supported
+		// hsm.Transition("wildcard", hsm.On("abcd*"), hsm.Source("/s"), hsm.Target("/s")),
 		hsm.Transition(hsm.On(dEvent), hsm.Source("/s"), hsm.Target("/s"), hsm.Effect(mockAction("s.D.transition.effect", false))),
 		hsm.Transition(hsm.On("C"), hsm.Source("/s/s1"), hsm.Target("/s/s2"), hsm.Effect(mockAction("s1.C.transition.effect", false))),
 		hsm.Transition(hsm.On("E"), hsm.Source("/s"), hsm.Target("/s/s1/s11"), hsm.Effect(mockAction("s.E.transition.effect", false))),
@@ -392,15 +394,16 @@ func TestComplex(t *testing.T) {
 	}) {
 		t.Fatal("transition actions are not correct", "trace", trace)
 	}
-	trace.reset()
-	<-sm.Dispatch(ctx, hsm.Event{
-		Name: "K.P.A",
-	})
-	if !trace.contains(Trace{
-		sync: []string{"s11.P.transition.effect"},
-	}) {
-		t.Fatal("transition actions are not correct", "trace", trace)
-	}
+	// Wildcard events are no longer supported
+	// trace.reset()
+	// <-sm.Dispatch(ctx, hsm.Event{
+	// 	Name: "K.P.A",
+	// })
+	// if !trace.contains(Trace{
+	// 	sync: []string{"s11.P.transition.effect"},
+	// }) {
+	// 	t.Fatal("transition actions are not correct", "trace", trace)
+	// }
 	trace.reset()
 	<-sm.Dispatch(ctx, hsm.Event{Name: "Z"})
 	if sm.State() != "/s/s3" {
@@ -1247,7 +1250,8 @@ func BenchmarkModel(b *testing.B) {
 					hsm.Activity(noBehavior),
 					hsm.Exit(noBehavior),
 				),
-				hsm.Transition(hsm.On(`*.P.*`), hsm.Effect(noBehavior)),
+				// Wildcard events are no longer supported
+			// hsm.Transition(hsm.On(`*.P.*`), hsm.Effect(noBehavior)),
 			),
 			hsm.State("t",
 				hsm.Entry(noBehavior),
@@ -1280,7 +1284,8 @@ func BenchmarkModel(b *testing.B) {
 			hsm.Transition(hsm.On("D"), hsm.Source("/s/s1"), hsm.Target("/s"), hsm.Effect(noBehavior), hsm.Guard(
 				noGuard,
 			)),
-			hsm.Transition("wildcard", hsm.On("abcd*"), hsm.Source("/s"), hsm.Target("/s")),
+			// Wildcard events are no longer supported
+		// hsm.Transition("wildcard", hsm.On("abcd*"), hsm.Source("/s"), hsm.Target("/s")),
 			hsm.Transition(hsm.On("D"), hsm.Source("/s"), hsm.Target("/s"), hsm.Effect(noBehavior)),
 			hsm.Transition(hsm.On("C"), hsm.Source("/s/s1"), hsm.Target("/s/s2"), hsm.Effect(noBehavior)),
 			hsm.Transition(hsm.On("E"), hsm.Source("/s"), hsm.Target("/s/s1/s11"), hsm.Effect(noBehavior)),

--- a/muid/muid_test.go
+++ b/muid/muid_test.go
@@ -33,3 +33,9 @@ func TestMUIDStringLength(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkMUID(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Make()
+	}
+}

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package hsm
 
 // Version is the current version of the hsm package.
-const Version = "v2.1.2"
+const Version = "v2.1.3"

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package hsm
 
 // Version is the current version of the hsm package.
-const Version = "v2.1.3"
+const Version = "v2.2.0"


### PR DESCRIPTION
- Commented out transition definitions that utilize wildcard events, as they are no longer supported.
- Introduced a new transitionMap for efficient lookup of transitions by state and event name, improving performance.
- Added a deferredMap for quick access to deferred events, enhancing event processing efficiency.
- Updated the enabled and process methods to utilize the new maps for faster transition handling.